### PR TITLE
Fix reversing bitstring for negative glues

### DIFF
--- a/src/ThreeTiles.civet
+++ b/src/ThreeTiles.civet
@@ -78,6 +78,7 @@ function wheel(t: Turtle, tiles: Prototile[], nBits: number): Turtle[]
       bits.unshift 0, 0
       bits.push 0, 1
     else
+      bits.reverse()
       bits.unshift 1, 0
       bits.push 0, 0
 


### PR DESCRIPTION
Adds a reverse operation before the prepend 10 and append 00 operations for negative glues. The missing reverse caused glues that were encoded with assymetric bitstrings (before appending/prepending 00/01) to not match when they were rotated to face eachother. In the example with 11 tiles this affected the blue and cyan glues which were encoded 
| Glue | Encoding |
| -------- | ------- |
| Blue + | 00 011 01  |
| Blue -  | 10 011 00 |
| Cyan +    | 00 110 01   |
| Cyan -    | 10 110 00   |

causing the positive blue glue to match with the negative cyan instead of the negative blue.